### PR TITLE
disable csrf, #180

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -44,7 +44,7 @@ module.exports = function(app, config, passport) {
     // should be after session
     app.use(flash());
 
-    app.use(express.csrf());
+    //app.use(express.csrf());
 
     // This could be moved to view-helpers :-)
     app.use(function(req, res, next){


### PR DESCRIPTION
sorry my pc has some pb with nodejs caused by .NET framework and i don't want to fix it for now so i just disabled the csrf. i thought the `res.locals.csrf_token = req.csrfToken();` should be left there coz there are everywhere in views, right?
